### PR TITLE
hopefully fixed a bug for computers that had gone to sleep

### DIFF
--- a/lib/socket_logic.js
+++ b/lib/socket_logic.js
@@ -198,8 +198,11 @@ io.on('connection', function(socket) {
   });
 
   socket.on('join-queue', function(data) {
-    let room = { id: newId() };
-    gameSeeker(socket);
+    if(socket.user_name){
+      gameSeeker(socket);
+    } else {
+      socket.emit('refresh-page', 'An error occurred')
+    }
   });
 
   socket.on('join-game', function(data){
@@ -207,7 +210,11 @@ io.on('connection', function(socket) {
   });
 
   socket.on('make-game', function(data){
-    buildGame(socket);
+    if(socket.user_name){
+      buildGame(socket);
+    } else {
+      socket.emit('refresh-page', 'An error occurred')
+    }
   });
 
   socket.on('game-over', function(data) {

--- a/public/scripts/app.js
+++ b/public/scripts/app.js
@@ -83,6 +83,10 @@ socket.on('existing-game', function() {
     displayButtonsJoinQueue();
 });
 
+socket.on('refresh-page', function() {
+  window.location.reload();
+});
+
 /*
  * Announces that user is going offline, so they can be removed from the
  * active player list and removes their active games if any


### PR DESCRIPTION
If a computer goes to sleep with the website open on a browser, when the computer wakes back up he can create/join games but his new socket will not have the user data, therefore will show as 'undefined' when they take actions.

This fix checks if the socket has user data before allowing them to make/join games, if not it reloads the clients window (which resets the socket)